### PR TITLE
Fixed text align issue in humans.txt display

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,6 +50,10 @@
         .button:hover {
             background-color: #e74c3c;
         }
+
+        #humans {
+          text-align: left;
+        }
     </style>
     <title>humans.txt validator</title>
     <script>


### PR DESCRIPTION
Originally if you enter `netflix.com`, this is what it would looks like: 
![vivaldi_292](https://github.com/sebiboga/humans-txt/assets/27590321/2dcee181-6d34-4fa2-92f9-6af715a9d214)

But this PR fixes that as it prevent display from messing up due to lack of trailing whitespaces.

Final result:
![vivaldi_293](https://github.com/sebiboga/humans-txt/assets/27590321/b069934a-405a-489a-9e62-87f73dc7e2e2)