### PR TITLE
Fix UI Bug - Hide Empty Box Until Check Button Is Clicked

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
         }
 
         .result-container {
+            display: none;
             max-width: 1200px;
             margin-left: 50px;
             margin-right: 50px;
@@ -122,7 +123,19 @@
           domainElement.textContent = "Invalid URL";
           humansElement.textContent = "humans.txt: -";
         }
+
+        showResultContainer();
       }
+
+      function showResultContainer() {
+        const resultContainerElement = document.querySelector(".result-container");
+
+        if (resultContainerElement) {
+            resultContainerElement.style.display = "block";
+        } else {
+            console.warn("No element with the class 'result-container' found.");
+        }
+      }    
     </script>
   </head>
   <body>


### PR DESCRIPTION
Description:
Fixed a UI bug where an empty box was displayed upon page load. This could be misleading or confusing for users. With this fix:

The box is now hidden when the page is loaded.
The box becomes visible only when the "Check!" button is clicked.

Screenshots:
Before:
![before2](https://github.com/sebiboga/humans-txt/assets/714741/4eaf16bf-5c60-49e4-92d8-f871990fe686)

After:
![after2](https://github.com/sebiboga/humans-txt/assets/714741/fc2b9e39-b815-4b66-96b1-0f269c0f7865)


Would appreciate feedback and further suggestions if any!